### PR TITLE
Handle missing API key and add fallback intent classifier

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     # A list of origins that should be permitted to make cross-origin requests.
     BACKEND_CORS_ORIGINS: List[Union[AnyHttpUrl, str]] = ["*"]
 
-    GOOGLE_API_KEY: str
+    GOOGLE_API_KEY: str | None = None
 
     class Config:
         env_file = ".env"

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -17,6 +17,7 @@ from app.core.prompts import (
 from app.crud import crud_conversation
 from app.api.v1.schemas.analytics import ConversationCreate
 from app.services.stream_manager import _ChatStreamManager
+from app.core.utils import create_mailto_link
 
 
 class ChatService:
@@ -25,21 +26,39 @@ class ChatService:
     Delegates stream processing to _ChatStreamManager for cleaner execution.
     """
     def __init__(self):
-        self.llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
-            google_api_key=settings.GOOGLE_API_KEY,
-            temperature=0.3,
-        )
         self.store: Dict[str, ChatMessageHistory] = {}
-        self.retriever = get_retriever()
         self.UserIntent = UserIntent
+
+        self.llm = None
+        self.retriever = None
+        if settings.GOOGLE_API_KEY:
+            self.llm = ChatGoogleGenerativeAI(
+                model="gemini-2.5-flash",
+                google_api_key=settings.GOOGLE_API_KEY,
+                temperature=0.3,
+            )
+            try:
+                self.retriever = get_retriever()
+            except Exception as e:
+                print(f"Error initializing retriever: {e}")
 
     def get_session_history(self, session_id: str) -> ChatMessageHistory:
         if session_id not in self.store:
             self.store[session_id] = ChatMessageHistory()
         return self.store[session_id]
 
+    def _basic_intent_classification(self, message: str) -> UserIntent:
+        msg = message.lower()
+        if "email" in msg:
+            return UserIntent.CREATE_EMAIL
+        if any(keyword in msg for keyword in ["hire", "hiring", "recruiter", "role", "position"]):
+            return UserIntent.RECRUITER
+        return UserIntent.GENERAL_INQUIRY
+
     async def _get_user_intent(self, message: str) -> UserIntent:
+        if not self.llm:
+            return self._basic_intent_classification(message)
+
         prompt = ChatPromptTemplate.from_template(INTENT_CLASSIFICATION_PROMPT_TEMPLATE)
         chain = prompt | self.llm
         try:
@@ -52,9 +71,12 @@ class ChatService:
             return UserIntent.GENERAL_INQUIRY
         except Exception as e:
             print(f"Error classifying user intent: {e}")
-            return UserIntent.GENERAL_INQUIRY
+            return self._basic_intent_classification(message)
 
     async def _generate_suggested_questions(self, question: str, answer: str) -> Optional[List[str]]:
+        if not self.llm:
+            return None
+
         prompt = ChatPromptTemplate.from_template(SUGGESTED_QUESTIONS_PROMPT_TEMPLATE)
         chain = prompt | self.llm
         try:


### PR DESCRIPTION
## Summary
- Allow `Settings` to load without `GOOGLE_API_KEY` and lazy-load retriever only when the key is provided
- Build `ChatService` to skip heavy initialization when the API key is absent and use a simple keyword-based intent classifier
- Re-export `create_mailto_link` for tests by importing from utils

## Testing
- `pytest -q`
